### PR TITLE
chore: Change linebreak style to Windows in ESLint config

### DIFF
--- a/packages/@config/eslint-config/index.js
+++ b/packages/@config/eslint-config/index.js
@@ -42,7 +42,7 @@ module.exports = [
       'no-var': 'error',
       'prefer-const': 'warn',
       'object-shorthand': 'error',
-      'linebreak-style': ['error', 'unix'],
+      'linebreak-style': ['error', 'windows'],
       'no-undef': 'off', // Disable no-undef for React/JSX in TypeScript files
 
       // React


### PR DESCRIPTION
Update the ESLint configuration to use Windows linebreak style instead of Unix.